### PR TITLE
feat: pass Ryder port and listening address as arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ryder-bridge-rust"
 version = "0.1.0"
 edition = "2021"
+default-run = "ryder-bridge-rust"
 
 
 [dependencies]


### PR DESCRIPTION
Ryder port and listening address are now passed via arguments.

```
cargo run "/dev/ttys001" "127.0.0.1:8080"
```

Also adds a default run binary.

Closes #1